### PR TITLE
Changed nuspec since we need UniqueDataAnnotation which is available …

### DIFF
--- a/source/Jobbr.Storage.MsSql.nuspec
+++ b/source/Jobbr.Storage.MsSql.nuspec
@@ -13,11 +13,11 @@
     <dependencies>
       <dependency id="Jobbr.ComponentModel.Registration" version="[1.0,1.1)"/>
       <dependency id="Jobbr.ComponentModel.JobStorage" version="[1.1,1.2)"/>
-      <dependency id="ServiceStack.Common" version="[5,6)"/>
-      <dependency id="ServiceStack.Interfaces" version="[5,6)"/>
-      <dependency id="ServiceStack.OrmLite" version="[5,6)"/>
-      <dependency id="ServiceStack.OrmLite.SqlServer" version="[5,6)"/>
-      <dependency id="ServiceStack.Text" version="[5,6)"/>
+      <dependency id="ServiceStack.Common" version="[5.1,6)"/>
+      <dependency id="ServiceStack.Interfaces" version="[5.1,6)"/>
+      <dependency id="ServiceStack.OrmLite" version="[5.1,6)"/>
+      <dependency id="ServiceStack.OrmLite.SqlServer" version="[5.1,6)"/>
+      <dependency id="ServiceStack.Text" version="[5.1,6)"/>
     </dependencies>
   </metadata>
   <files>

--- a/source/Jobbr.Storage.MsSql/OrderExtensions.cs
+++ b/source/Jobbr.Storage.MsSql/OrderExtensions.cs
@@ -19,6 +19,7 @@ namespace Jobbr.Storage.MsSql
             { nameof(JobRun.PlannedStartDateTimeUtc), run => run.PlannedStartDateTimeUtc },
             { nameof(JobRun.Progress), run => run.Progress },
             { nameof(JobRun.ActualEndDateTimeUtc), run => run.ActualEndDateTimeUtc },
+            { nameof(JobRun.ActualStartDateTimeUtc), run => run.ActualStartDateTimeUtc },
             { nameof(JobRun.EstimatedEndDateTimeUtc), run => run.EstimatedEndDateTimeUtc },
             { nameof(JobRun.State), run => run.State }
         };


### PR DESCRIPTION
We need UniqueAttribute from ServiceStack.Interfaces which is defined in Version 5.1.
Regarding to our nuspec-file the minimal required version is 5.0.
This will result in a runtime-error, because the attribute cannot be found.